### PR TITLE
Implement minimal OAuth 2.0 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# codex-OAuth2
+# OAuth 2.0 Sample Server
+
+This repository provides a minimal OAuth 2.0 authorization server written in ASP.NET Core 8 (compatible with upcoming .NET 9) using Entity Framework Core for persistence and Redis for caching.
+
+## Endpoints
+
+- `GET /oauth/authorize` — Authorization endpoint implementing the Authorization Code flow. Validates client information and issues an authorization code via redirect.
+- `POST /oauth/token` — Token endpoint for exchanging an authorization code for an access token.
+- `POST /oauth/introspect` — Token introspection endpoint returning token activity and expiration information.
+- `POST /oauth/revoke` — Revocation endpoint to invalidate issued access tokens.
+
+The server uses `AuthDbContext` (Entity Framework Core) to store clients, authorization codes, and access tokens. `TokenCache` demonstrates integration with Redis if token caching is desired.
+
+The code is intentionally minimal and meant for educational purposes, showing how OAuth 2.0 APIs can be structured.

--- a/src/OAuthServer/Controllers/AuthorizationController.cs
+++ b/src/OAuthServer/Controllers/AuthorizationController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+using OAuthServer.Models;
+using OAuthServer.Services;
+
+namespace OAuthServer.Controllers;
+
+[ApiController]
+[Route("oauth/authorize")]
+public class AuthorizationController : ControllerBase
+{
+    private readonly AuthDbContext _db;
+
+    public AuthorizationController(AuthDbContext db) => _db = db;
+
+    [HttpGet]
+    public IActionResult Authorize([FromQuery] string response_type, [FromQuery] string client_id, [FromQuery] string redirect_uri)
+    {
+        var client = _db.Clients.FirstOrDefault(c => c.ClientId == client_id && c.RedirectUri == redirect_uri);
+        if (client == null || response_type != "code")
+            return BadRequest();
+
+        var code = new AuthorizationCode
+        {
+            Code = Guid.NewGuid().ToString("N"),
+            ClientId = client_id,
+            RedirectUri = redirect_uri,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(5)
+        };
+        _db.AuthorizationCodes.Add(code);
+        _db.SaveChanges();
+
+        return Redirect($"{redirect_uri}?code={code.Code}");
+    }
+}

--- a/src/OAuthServer/Controllers/IntrospectionController.cs
+++ b/src/OAuthServer/Controllers/IntrospectionController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using OAuthServer.Services;
+
+namespace OAuthServer.Controllers;
+
+[ApiController]
+[Route("oauth/introspect")]
+public class IntrospectionController : ControllerBase
+{
+    private readonly AuthDbContext _db;
+
+    public IntrospectionController(AuthDbContext db) => _db = db;
+
+    [HttpPost]
+    public IActionResult Introspect([FromForm] string token)
+    {
+        var accessToken = _db.AccessTokens.FirstOrDefault(t => t.Token == token);
+        if (accessToken == null)
+            return Ok(new { active = false });
+
+        var active = accessToken.ExpiresAt > DateTime.UtcNow;
+        return Ok(new { active, exp = new DateTimeOffset(accessToken.ExpiresAt).ToUnixTimeSeconds() });
+    }
+}

--- a/src/OAuthServer/Controllers/RevocationController.cs
+++ b/src/OAuthServer/Controllers/RevocationController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using OAuthServer.Services;
+
+namespace OAuthServer.Controllers;
+
+[ApiController]
+[Route("oauth/revoke")]
+public class RevocationController : ControllerBase
+{
+    private readonly AuthDbContext _db;
+
+    public RevocationController(AuthDbContext db) => _db = db;
+
+    [HttpPost]
+    public IActionResult Revoke([FromForm] string token)
+    {
+        var accessToken = _db.AccessTokens.FirstOrDefault(t => t.Token == token);
+        if (accessToken != null)
+        {
+            _db.AccessTokens.Remove(accessToken);
+            _db.SaveChanges();
+        }
+
+        return Ok();
+    }
+}

--- a/src/OAuthServer/Controllers/TokenController.cs
+++ b/src/OAuthServer/Controllers/TokenController.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc;
+using OAuthServer.Models;
+using OAuthServer.Services;
+
+namespace OAuthServer.Controllers;
+
+[ApiController]
+[Route("oauth/token")]
+public class TokenController : ControllerBase
+{
+    private readonly AuthDbContext _db;
+
+    public TokenController(AuthDbContext db) => _db = db;
+
+    [HttpPost]
+    public IActionResult Token([FromForm] string grant_type, [FromForm] string code, [FromForm] string redirect_uri, [FromForm] string client_id, [FromForm] string client_secret)
+    {
+        var client = _db.Clients.FirstOrDefault(c => c.ClientId == client_id && c.ClientSecret == client_secret);
+        if (client == null)
+            return Unauthorized();
+
+        if (grant_type == "authorization_code")
+        {
+            var authCode = _db.AuthorizationCodes.FirstOrDefault(a => a.Code == code && a.ClientId == client_id);
+            if (authCode == null || authCode.RedirectUri != redirect_uri || authCode.ExpiresAt < DateTime.UtcNow)
+                return BadRequest();
+
+            _db.AuthorizationCodes.Remove(authCode);
+
+            var token = new AccessToken
+            {
+                Token = Guid.NewGuid().ToString("N"),
+                ClientId = client_id,
+                ExpiresAt = DateTime.UtcNow.AddHours(1)
+            };
+            _db.AccessTokens.Add(token);
+            _db.SaveChanges();
+
+            return Ok(new { access_token = token.Token, token_type = "bearer", expires_in = 3600 });
+        }
+
+        return BadRequest();
+    }
+}

--- a/src/OAuthServer/Models/AccessToken.cs
+++ b/src/OAuthServer/Models/AccessToken.cs
@@ -1,0 +1,9 @@
+namespace OAuthServer.Models;
+
+public class AccessToken
+{
+    public int Id { get; set; }
+    public required string Token { get; set; }
+    public required string ClientId { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}

--- a/src/OAuthServer/Models/AuthorizationCode.cs
+++ b/src/OAuthServer/Models/AuthorizationCode.cs
@@ -1,0 +1,10 @@
+namespace OAuthServer.Models;
+
+public class AuthorizationCode
+{
+    public int Id { get; set; }
+    public required string Code { get; set; }
+    public required string ClientId { get; set; }
+    public required string RedirectUri { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}

--- a/src/OAuthServer/Models/Client.cs
+++ b/src/OAuthServer/Models/Client.cs
@@ -1,0 +1,9 @@
+namespace OAuthServer.Models;
+
+public class Client
+{
+    public int Id { get; set; }
+    public required string ClientId { get; set; }
+    public required string ClientSecret { get; set; }
+    public required string RedirectUri { get; set; }
+}

--- a/src/OAuthServer/OAuthServer.csproj
+++ b/src/OAuthServer/OAuthServer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Npgsql" Version="8.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.123" />
+  </ItemGroup>
+</Project>

--- a/src/OAuthServer/Program.cs
+++ b/src/OAuthServer/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OAuthServer.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure services
+builder.Services.AddControllers();
+// EF Core with configuration for SQL Server or PostgreSQL
+builder.Services.AddDbContext<AuthDbContext>();
+// Redis cache for tokens or sessions
+builder.Services.AddSingleton<TokenCache>();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();
+

--- a/src/OAuthServer/Services/AuthDbContext.cs
+++ b/src/OAuthServer/Services/AuthDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using OAuthServer.Models;
+
+namespace OAuthServer.Services;
+
+public class AuthDbContext : DbContext
+{
+    public AuthDbContext(DbContextOptions<AuthDbContext> options) : base(options) {}
+
+    public DbSet<Client> Clients => Set<Client>();
+    public DbSet<AuthorizationCode> AuthorizationCodes => Set<AuthorizationCode>();
+    public DbSet<AccessToken> AccessTokens => Set<AccessToken>();
+}

--- a/src/OAuthServer/Services/TokenCache.cs
+++ b/src/OAuthServer/Services/TokenCache.cs
@@ -1,0 +1,19 @@
+using StackExchange.Redis;
+
+namespace OAuthServer.Services;
+
+public class TokenCache
+{
+    private readonly IDatabase _db;
+
+    public TokenCache(IConnectionMultiplexer multiplexer)
+    {
+        _db = multiplexer.GetDatabase();
+    }
+
+    public async Task SetTokenAsync(string key, string token, TimeSpan lifetime)
+        => await _db.StringSetAsync(key, token, lifetime);
+
+    public async Task<string?> GetTokenAsync(string key)
+        => await _db.StringGetAsync(key);
+}


### PR DESCRIPTION
## Summary
- add ASP.NET Core project skeleton for OAuth 2.0 server
- implement Authorization, Token, Introspection and Revocation endpoints
- provide EF Core context, Redis token cache, and basic models
- document available endpoints in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684543e53c188328aca7bc9fb777e24d